### PR TITLE
Wrapped projectPath in quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ if(!command[1]){
   return lineup.log.warn('Specify project name')
 }
 
-const projectPath = path.join(process.cwd(),command[1])
+const projectPath = '"' + path.join(process.cwd(),command[1]) + '"';
 
 lineup.progress.start('setting up project files ....')
 


### PR DESCRIPTION
git clone doesn't support folders with spaces in them without wrapping the path in quotes. I added quotes to the project path so that the adonis new path will automatically throw those in.
